### PR TITLE
[Bugfix] fix localtime "'localtime': This function or variable may be unsafe." error

### DIFF
--- a/ssd-cli-test/Logger.cpp
+++ b/ssd-cli-test/Logger.cpp
@@ -59,7 +59,9 @@ private:
 
 	string makeDateString(DateType dateType) {
 		std::time_t now = std::time(nullptr);
-		std::tm* current_time = std::localtime(&now);
+		std::tm* current_time;
+		localtime_s(current_time, &now);
+
 		stringstream ss{};
 		switch (dateType)
 		{


### PR DESCRIPTION
logger 에서 발생하는 error 수정합니다.